### PR TITLE
Add support for embedding HTML directly when marked as safe

### DIFF
--- a/diff.seru
+++ b/diff.seru
@@ -5,7 +5,7 @@ from @core import Map, List, Set
 from webidl`dom` import Element, Node, document
 
 from internal import getDOMPath, setDOMPath
-from types import VirtualNode, FunctionReference
+from types import VirtualNode, FunctionReference, SafeHTML
 from wrappers import DOMNode, DOMError, VirtualNodeWrapper, keyAttachment
 
 var diff_replace_node string = 'replace-node'
@@ -39,8 +39,22 @@ struct Diff {
 	 * The index of this diff's starting node in the parent node.
 	 */
 	NodeIndex int
+
+	/**
+	 * ReplacementNode is the virtual node replacing or being added at
+	 * the current location of this diff. Will be null for nodes being
+	 * removed.
+	 */
 	ReplacementNode VirtualNode?
+
+	/**
+	 * Children are the diffs for the children of this node, if any.
+	 */
 	Children []Diff
+
+	/**
+	 * Attributes are the diffs of the attributes of this node, if any.
+	 */
 	Attributes []AttributeDiff
 }
 
@@ -56,6 +70,13 @@ function generateId() string {
  * given node.
  */
 function buildDOM(vNode VirtualNode, parentPath string, reporter DiffReporter?) Node {
+	contents := vNode.SafeHTMLContents
+	if contents is not null {
+		element := document.createElement('span')
+		element['innerHTML'] = &contents
+		return element
+	}
+
 	if vNode.TagName is null {
 		return document.createTextNode(&(vNode.Text!))
 	}
@@ -85,7 +106,7 @@ function buildDOM(vNode VirtualNode, parentPath string, reporter DiffReporter?) 
 		for child in children {
 			built := buildDOM(child, elementPath, reporter)
 			node.appendChild(built)
-			(reporter?.NodeCreated)(child, built)
+			reporter?.NodeCreated(child, built)
 		}
 	}
 
@@ -119,6 +140,8 @@ function ComputeDiff(updated VirtualNode, existing DOMNode) Diff {
 function ApplyDiff(diff Diff, domNode Node, reporter DiffReporter?) {
 	switch diff.Type {
 		case diff_same:
+			// Nothing to do
+			return
 
 		case diff_thunk:
 			// Update any attributes.
@@ -130,29 +153,40 @@ function ApplyDiff(diff Diff, domNode Node, reporter DiffReporter?) {
 				}
 			}
 
+			contents := diff.ReplacementNode?.SafeHTMLContents
+			if contents is not null {
+				element := domNode.(Element)
+				existingContents := string(element['innerHTML'].(DOMString))
+				if existingContents != string(contents) {
+					element['innerHTML'] = &contents
+				}
+			}
+
 			// Report the update.
-			(reporter?.NodeUpdated)(diff.ReplacementNode!, domNode)
+			reporter?.NodeUpdated(diff.ReplacementNode!, domNode)
 
 			// Process child diffs.
-			for childDiff in diff.Children {
-				if childDiff.Type == diff_create_node {
-					ApplyDiff(childDiff, domNode, reporter)
-					continue
-				}
+			if contents is null {
+				for childDiff in diff.Children {
+					if childDiff.Type == diff_create_node {
+						ApplyDiff(childDiff, domNode, reporter)
+						continue
+					}
 
-				var child = domNode.(Element).childNodes[&childDiff.NodeIndex]
-				if child is null {
-					reject DOMError.WithMessage('Missing expected child')
-				}
+					var child = domNode.(Element).childNodes[&childDiff.NodeIndex]
+					if child is null {
+						reject DOMError.WithMessage('Missing expected child')
+					}
 
-				ApplyDiff(childDiff, child!, reporter)
+					ApplyDiff(childDiff, child!, reporter)
+				}
 			}
 
 		case diff_remove_node:
 			var parent = domNode.parentNode
 			if parent is not null {
 				parent.removeChild(domNode)
-				(reporter?.NodeRemoved)(domNode)
+				reporter?.NodeRemoved(domNode)
 			}
 
 		case diff_create_node:
@@ -161,14 +195,14 @@ function ApplyDiff(diff Diff, domNode Node, reporter DiffReporter?) {
 			var insertionBeforeIndex = diff.NodeIndex
 			if insertionBeforeIndex >= int(domNode.childNodes.length) {
 				domNode.appendChild(createdNode)
-				(reporter?.NodeCreated)(diff.ReplacementNode!, createdNode)
+				reporter?.NodeCreated(diff.ReplacementNode!, createdNode)
 				return
 			}
 
 			var existingChild = domNode.childNodes[&insertionBeforeIndex]
 			if existingChild is not null {
 				domNode.insertBefore(createdNode, existingChild)
-				(reporter?.NodeCreated)(diff.ReplacementNode!, createdNode)
+				reporter?.NodeCreated(diff.ReplacementNode!, createdNode)
 			}
 
 		case diff_replace_node:
@@ -178,8 +212,8 @@ function ApplyDiff(diff Diff, domNode Node, reporter DiffReporter?) {
 				var createdNode = buildDOM(diff.ReplacementNode!, parentPath, reporter)
 				parent.replaceChild(createdNode, domNode)
 
-				(reporter?.NodeCreated)(diff.ReplacementNode!, createdNode)
-				(reporter?.NodeRemoved)(domNode)
+				reporter?.NodeCreated(diff.ReplacementNode!, createdNode)
+				reporter?.NodeRemoved(domNode)
 			}
 	}
 }
@@ -279,6 +313,17 @@ function computeDiff(updatedNode VirtualNode, existing DOMNode, parentIndex int)
 			if existingValue is null || attributeValue! != existingValue! {
 				attributeDiffs.Add(AttributeDiff{Name: attributeName, Value: attributeValue})
 			}
+		}
+	}
+
+	// If there are contents of the node, then its children are simply replaced.
+	if updatedNode.SafeHTMLContents is not null {
+		return Diff{
+			Type: diff_thunk,
+			NodeIndex: parentIndex,
+			Children: []Diff{},
+			Attributes: attributeDiffs[0:],
+			ReplacementNode: updatedNode,
 		}
 	}
 

--- a/renderable.seru
+++ b/renderable.seru
@@ -1,7 +1,7 @@
 from @core import Map, List
 from @core import SimpleError, Stringable
 from eventmanager import EventManager
-from types import VirtualNode, FunctionReference
+from types import VirtualNode, FunctionReference, SafeHTML
 
 /**
  * RenderKeyed marks a renderable object with a comparison key for diff determination.
@@ -101,6 +101,9 @@ function RenderToVirtualNode(instance any, context Context) VirtualNode {
 				}
 
 				return typedValue
+
+			case SafeHTML:
+				return VirtualNode{SafeHTMLContents: typedValue, TagName: 'span'}
 
 			case renderableVirtualNode:
 				current = typedValue.renderUnderRoot(rootParent ?? typedValue, '', context)
@@ -223,6 +226,9 @@ class renderableVirtualNode {
 			match child as typedChild {
 				case string:
 					childList.Add(VirtualNode{Text: typedChild})
+
+				case SafeHTML:
+					childList.Add(VirtualNode{SafeHTMLContents: typedChild, TagName: 'span'})
 
 				case VirtualNode:
 					childList.Add(typedChild)

--- a/types.seru
+++ b/types.seru
@@ -4,6 +4,12 @@
 type FunctionReference : string {}
 
 /**
+ * SafeHTML is a block of HTML marked safe to be directly included. Note that no parsing or
+ * validation is done, so if bad HTML is included, it *can* cause XSS.
+ */
+type SafeHTML : string {}
+
+/**
  * VirtualNode defines a single virtual DOM node.
  */
 struct VirtualNode {
@@ -26,9 +32,15 @@ struct VirtualNode {
 	Key string?
 
 	/**
-	 * Text is the textual contents of the node, if any. If specified, TagName be null.
+	 * Text is the textual contents of the node, if any. If specified, TagName must be null.
 	 */
 	Text string?
+
+	/**
+	 * SafeHTMLContents, if specified, indicates the contents of this virtual node as a SafeHTML
+	 * block. Note if set the Children *must* be null.
+	 */
+	SafeHTMLContents SafeHTML?
 
 	/**
 	 * Children is the slice of children of this node, if any.

--- a/vdom.seru
+++ b/vdom.seru
@@ -1,4 +1,5 @@
 from renderable import renderableVirtualNode
+from types import VirtualNode, SafeHTML
 
 function A(props []{any}, childStream any*) renderableVirtualNode {
 	return renderableVirtualNode{tagName: 'a', props: props, children: childStream}
@@ -62,4 +63,22 @@ function Li(props []{any}, childStream any*) renderableVirtualNode {
 
 function Input(props []{any}, childStream any*) renderableVirtualNode {
 	return renderableVirtualNode{tagName: 'input', props: props, children: childStream}
+}
+
+struct safeHTMLProps {
+	TagName string?
+}
+
+/**
+ * MarkSafe represents an element added to the DOM tree containing the given `rawHTML`,
+ * unescaped. If `TagName` is unspecified in `props`, then the HTML is wrapped in a span.
+ *
+ * NOTE: Be *very careful* with the HTML given here, as it will *not* be escaped or checked
+ * in *any* fashion.
+ */
+function MarkSafe(props safeHTMLProps, rawHTML string) VirtualNode {
+	return VirtualNode{
+		TagName: props.TagName ?? 'span',
+		SafeHTMLContents: SafeHTML(rawHTML),
+	}
 }


### PR DESCRIPTION
Adds a new wrapping type of SafeHTML which can be directly added to a vdom tree to cause direct rendering